### PR TITLE
规范日志输出，便于定位问题

### DIFF
--- a/instock/bin/mac/run_job.sh
+++ b/instock/bin/mac/run_job.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+cd ..
+cd ..
+cd job
+echo "------整体作业，支持批量作业------"
+echo "当前时间作业 python execute_daily_job.py"
+echo "1个时间作业 python execute_daily_job.py 2023-03-01"
+echo "N个时间作业 python execute_daily_job.py 2023-03-01,2023-03-02"
+echo "区间作业 python execute_daily_job.py 2023-03-01 2023-03-21"
+echo "------单功能作业，除了创建数据库，其他都支持批量作业------"
+echo "创建数据库作业 python init_job.py"
+echo "基础数据作业 python basic_data_daily_job.py"
+echo "指标数据作业 python indicators_data_daily_job.py"
+echo "K线形态作业 python klinepattern_data_daily_job.py"
+echo "策略数据作业 python strategy_data_daily_job.py"
+echo "回测数据 python backtest_data_daily_job.py"
+echo "------正在执行作业中，请等待------"
+#python execute_daily_job.py 2022-01-24,2022-02-25,2022-03-24,2022-04-18,2022-05-18,2022-06-06,2022-07-21,2022-08-26,2022-09-16,2022-10-28,2022-11-04,2022-12-16
+#python execute_daily_job.py 2022-01-10,2022-02-14,2022-03-14,2022-04-11,2022-05-10,2022-06-13,2022-07-04,2022-08-08,2022-09-05,2022-10-11,2022-11-14,2022-12-05
+#python execute_daily_job.py 2022-05-18 2022-05-25
+python execute_daily_job.py

--- a/instock/bin/mac/run_web.sh
+++ b/instock/bin/mac/run_web.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+cd ..
+cd ..
+cd web
+
+python web_service.py
+
+
+echo ------Web服务已启动 请不要关闭------
+echo 访问地址 : http://localhost:9988/

--- a/instock/job/execute_daily_job.py
+++ b/instock/job/execute_daily_job.py
@@ -14,9 +14,13 @@ cpath_current = os.path.dirname(os.path.dirname(__file__))
 cpath = os.path.abspath(os.path.join(cpath_current, os.pardir))
 sys.path.append(cpath)
 log_path = os.path.join(cpath_current, 'log')
-if not os.path.exists(log_path):
-    os.makedirs(log_path)
-logging.basicConfig(format='%(asctime)s %(message)s', filename=os.path.join(log_path, 'stock_execute_job.log'))
+log_execute_job_path = os.path.join(cpath_current, 'log/job')
+if not os.path.exists(log_execute_job_path):
+    os.makedirs(log_execute_job_path)
+
+current_time = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+log_filename = 'stock_execute_job-{}.log'.format(current_time)
+logging.basicConfig(format='%(asctime)s %(message)s', filename=os.path.join(log_execute_job_path, log_filename))
 logging.getLogger().setLevel(logging.INFO)
 import init_job as bj
 import basic_data_daily_job as hdj

--- a/instock/web/web_service.py
+++ b/instock/web/web_service.py
@@ -4,6 +4,7 @@
 import logging
 import os.path
 import sys
+import datetime
 from abc import ABC
 import tornado.escape
 from tornado import gen
@@ -16,9 +17,13 @@ cpath_current = os.path.dirname(os.path.dirname(__file__))
 cpath = os.path.abspath(os.path.join(cpath_current, os.pardir))
 sys.path.append(cpath)
 log_path = os.path.join(cpath_current, 'log')
-if not os.path.exists(log_path):
-    os.makedirs(log_path)
-logging.basicConfig(format='%(asctime)s %(message)s', filename=os.path.join(log_path, 'stock_web.log'))
+log_web_path = os.path.join(cpath_current, 'log/web')
+if not os.path.exists(log_web_path):
+    os.makedirs(log_web_path)
+
+current_time = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+log_filename = 'stock_web_service-{}.log'.format(current_time)
+logging.basicConfig(format='%(asctime)s %(message)s', filename=os.path.join(log_web_path, log_filename))
 logging.getLogger().setLevel(logging.ERROR)
 import instock.lib.torndb as torndb
 import instock.lib.database as mdb


### PR DESCRIPTION
将每次执行的日志单独以一个文件保存，方便查看单次执行的日志，便于定位问题
格式如下：
<img width="410" alt="image" src="https://user-images.githubusercontent.com/16517186/236206117-acd912e5-1af1-4bfb-974d-10276456dbec.png">

