### PR TITLE
修正execute_daily_job.py批量作业不能工作问题。

### DIFF
--- a/instock/job/basic_data_daily_job.py
+++ b/instock/job/basic_data_daily_job.py
@@ -24,7 +24,10 @@ def save_nph_stock_spot_data(date, before=True):
         return
     # 股票列表
     try:
-        data = stock_data(date).get_data()
+        if len(sys.argv) == 1:  #当日一天
+            data = stock_data(date).get_data() 
+        else:  #多参数多天
+            data = stf.fetch_stocks(date)
         if data is None or len(data.index) == 0:
             return
 

--- a/instock/lib/run_template.py
+++ b/instock/lib/run_template.py
@@ -26,7 +26,10 @@ def run_with_args(run_fun, *args):
             with concurrent.futures.ThreadPoolExecutor() as executor:
                 while run_date <= end_date:
                     if trd.is_trade_date(run_date):
-                        executor.submit(run_fun, run_date, *args)
+                        if run_fun.__name__.startswith('save_nph'):
+                            executor.submit(run_fun, run_date, False)
+                        else:
+                            executor.submit(run_fun, run_date, *args)
                         time.sleep(2)
                     run_date += datetime.timedelta(days=1)
         except Exception as e:
@@ -40,7 +43,10 @@ def run_with_args(run_fun, *args):
                     tmp_year, tmp_month, tmp_day = date.split("-")
                     run_date = datetime.datetime(int(tmp_year), int(tmp_month), int(tmp_day)).date()
                     if trd.is_trade_date(run_date):
-                        executor.submit(run_fun, run_date, *args)
+                        if run_fun.__name__.startswith('save_nph'):
+                            executor.submit(run_fun, run_date, False)
+                        else:
+                            executor.submit(run_fun, run_date, *args)
                         time.sleep(2)
         except Exception as e:
             logging.error(f"run_template.run_with_args处理异常：{run_fun}{sys.argv}{e}")


### PR DESCRIPTION
说明文档中写明“整体作业，支持批量作业”
枚举时间作业 python execute_daily_job.py 2022-01-01,2021-02-08,2022-03-12
区间时间作业 python execute_daily_job.py 2022-01-01 2022-03-01

然而实际运行时，并不会获取之前的数据。

分析原因：
1、代码 lib/run_template.py 中 run_with_args(run_fun, *args) 函数 调用executor.submit(run_fun, run_date, *args)时相当于给run_fun（也就是save_nph_stock_spot_data ）没有传入第二个参数，也就before均为True，实际效果是不返回。
2、代码 job/basic_data_daily_job.py 中 save_nph_stock_spot_data 函数 stock_data(date).get_data()采用单例模式调用，实例中date并不会变化