### PR TITLE
改用mini-racer 0.12.4 代替py_mini_racer 0.6.0 执行js代码

### DIFF
--- a/instock/core/crawling/trade_date_hist.py
+++ b/instock/core/crawling/trade_date_hist.py
@@ -9,7 +9,7 @@ https://finance.sina.com.cn/realstock/company/klc_td_sh.txt
 import datetime
 import pandas as pd
 import requests
-from py_mini_racer import py_mini_racer
+from py_mini_racer import MiniRacer
 
 hk_js_decode = """
 function d(t) {
@@ -311,7 +311,7 @@ def tool_trade_date_hist_sina() -> pd.DataFrame:
     """
     url = "https://finance.sina.com.cn/realstock/company/klc_td_sh.txt"
     r = requests.get(url)
-    js_code = py_mini_racer.MiniRacer()
+    js_code = MiniRacer()
     js_code.eval(hk_js_decode)
     dict_list = js_code.call(
         "d", r.text.split("=")[1].split(";")[0].replace('"', "")


### PR DESCRIPTION
tool_trade_date_hist_sina 代码中使用py_mini_racer 0.6.0 执行会报错，function 'mr_eval_context' not found。
py_mini_racer 0.6.0 好多年没有维护了，太老。更改使用https://pypi.org/project/mini-racer/ 代替。