### PR TITLE
利用MySQL ON DUPLICATE KEY UPDATE方法解决重复执行一些任务出现IntegrityError错误问题

### DIFF
--- a/instock/lib/database.py
+++ b/instock/lib/database.py
@@ -89,15 +89,16 @@ def insert_other_db_from_df(to_db, data, table_name, cols_type, write_index, pri
         col_name_list.insert(0, data.index.name)
     method=insert_on_duplicate(except_cols_on_update=primary_keys.split(','))
     try:
-        if cols_type is None:
-            data.to_sql(name=table_name, con=engine_mysql, schema=to_db, if_exists='append',
-                        index=write_index, method=method, )
-        elif not cols_type:
-            data.to_sql(name=table_name, con=engine_mysql, schema=to_db, if_exists='append',
-                        dtype={col_name: NVARCHAR(255) for col_name in col_name_list}, index=write_index, method=method, )
-        else:
-            data.to_sql(name=table_name, con=engine_mysql, schema=to_db, if_exists='append',
-                        dtype=cols_type, index=write_index, method=method, )
+        with engine_mysql.begin() as conn:
+            if cols_type is None:
+                data.to_sql(name=table_name, con=conn, schema=to_db, if_exists='append',
+                            index=write_index, method=method, )
+            elif not cols_type:
+                data.to_sql(name=table_name, con=conn, schema=to_db, if_exists='append',
+                            dtype={col_name: NVARCHAR(255) for col_name in col_name_list}, index=write_index, method=method, )
+            else:
+                data.to_sql(name=table_name, con=conn, schema=to_db, if_exists='append',
+                            dtype=cols_type, index=write_index, method=method, )
     except Exception as e:
         logging.error(f"database.insert_other_db_from_df处理异常：{table_name}表{e}")
 


### PR DESCRIPTION
 selection job如果被执行多次，会出现类似以下错误：
database.insert_other_db_from_df处理异常：cn_stock_selection表(pymysql.err.IntegrityError) (1062, "Duplicate entry '2024-12-17-300071' for key 'PRIMARY'")

使用mysql方法来解决这个问题。