### PR TITLE
harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ cython_debug/
 cache/
 log/
 test/
+
+.obsidian/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# AGENTS.md
+
+InStock 股票量化系统导航地图。本文档为入口索引，详细设计见 `docs/`。
+
+## 1. 项目定位
+
+InStock：基于 Python 3.11 + Tornado + MariaDB + TA-Lib + easytrader + supervisord 的 A 股量化系统，覆盖数据抓取、指标/形态计算、选股策略、回测、Web 展示与实盘交易。
+
+## 2. 目录地图
+
+- `instock/bin/` — 启动脚本（`run_web.sh`、`run_job.sh`、`run_cron.sh`），见 `instock/bin/run_web.sh:3`、`instock/bin/run_job.sh:6`、`instock/bin/run_cron.sh:9`。
+- `instock/config/` — 配置文件：`eastmoney_cookie.txt`、`proxy.txt`、`trade_client.json`。
+- `instock/core/` — 核心层：抓取 `crawling/`、指标 `indicator/`、K线 `kline/`、形态 `pattern/`、策略 `strategy/`、回测 `backtest/`，加 `eastmoney_fetcher.py`、`stockfetch.py`、`tablestructure.py`、`singleton_*.py`。
+- `instock/job/` — 作业调度层：`execute_daily_job.py` 编排全部日作业，`init_job.py` 建库，其余 9 个 `*_daily_job.py` 各管一域。
+- `instock/lib/` — 基础库：`database.py`（DB 读写）、`torndb.py`（Tornado DB 包装）、`run_template.py`（日期参数化批跑）、`trade_time.py`（交易时间）、`singleton_type.py`、`crypto_aes.py`、`version.py`。
+- `instock/trade/` — 交易引擎：`robot/engine/`（`main_engine.py`、`clock_engine.py`、`event_engine.py`）、`robot/infrastructure/`（`strategy_template.py`、`default_handler.py`）、`strategies/`（`stagging.py` 等）、`trade_service.py`。
+- `instock/web/` — Web 层：`web_service.py`（Tornado 入口，端口 9988）、`base.py`、`dataTableHandler.py`、`dataIndicatorsHandler.py`、`templates/`、`static/`。
+- `cron/` — 容器内 cron 脚本：`cron.hourly/run_hourly`、`cron.workdayly/run_workdayly`、`cron.monthly/run_monthly`。
+- `docker/` — `Dockerfile`、`docker-compose.yml`、`build.sh`。
+- `supervisor/` — `supervisord.conf`，跑 `run_job`/`run_web`/`run_cron` 三个 program，见 `supervisor/supervisord.conf:25-42`。
+
+## 3. 关键命令
+
+详细命令与依赖说明见 `docs/DEVELOPMENT.md`。
+
+- 初始化 DB：`python instock/job/init_job.py`
+- 跑 web：`python instock/web/web_service.py`（端口 9988，`instock/web/web_service.py:76`）
+- 跑全部 job：`python instock/job/execute_daily_job.py`，支持单日/批量/区间参数，见 `instock/bin/run_job.sh:9-12`
+- 单个 job：`python instock/job/<job_name>.py`，例如 `python instock/job/basic_data_daily_job.py`
+- Docker：`cd docker && docker-compose up -d`
+- supervisord：`supervisord -c supervisor/supervisord.conf`
+- lint：`make lint-arch`（创建后）
+
+## 4. 架构入口
+
+分层与边界调用统计见 `docs/ARCHITECTURE.md`。入口点：作业 `execute_daily_job.py:35`、Web `web_service.py:71`、交易 `trade_service.py:19`。
+
+## 5. 约束与已知问题
+
+- **lib→core 循环**：`instock/lib/trade_time.py:5` import `instock.core.singleton_trade_date`，linter 会标记；既有结构，harness 不修。
+- **DB 配置走环境变量**：默认 localhost:3306/root/root/instockdb，可被 `db_host`/`db_user`/`db_password`/`db_database`/`db_port` 覆盖，见 `instock/lib/database.py:14-36`。
+- **PYTHONPATH**：容器内为 `/data/InStock`（`docker/Dockerfile:10`、`instock/bin/run_cron.sh:4`）；本地运行时各入口脚本自行 `sys.path.append` 项目根，见 `instock/web/web_service.py:16-18`、`instock/job/execute_daily_job.py:13-15`。
+- **TA-Lib 原生库**：需先编译安装 ta-lib native 再 `pip install TA-Lib`，编译步骤见 `docker/Dockerfile:46-53`。
+- **东方财富 Cookie**：优先级 `EAST_MONEY_COOKIE` 环境变量 > `instock/config/eastmoney_cookie.txt` > 默认值，见 `instock/core/eastmoney_fetcher.py:34-49`。
+
+## 6. 文档索引
+
+- `docs/ARCHITECTURE.md` — 分层、边界调用统计、热点函数、入口点清单。
+- `docs/DEVELOPMENT.md` — 环境准备、命令、cron 调度、配置文件。
+- `docs/design-docs/data-pipeline.md` — 抓取→落库→指标/形态→选股/策略→回测管线。
+- `docs/design-docs/trade-engine.md` — MainEngine / ClockEngine / StrategyTemplate / 事件引擎。
+- `docs/design-docs/web-layer.md` — Tornado 路由与 handler 结构。
+- `docs/design-docs/strategy-system.md` — 选股策略注册与调度机制。

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# InStock harness Makefile
+# ponytail: 最小可用目标集，不堆砌
+
+PY ?= python3
+LINT_DEPS := scripts/lint-deps.py
+LINT_QUALITY := scripts/lint-quality.py
+
+.PHONY: help install-deps lint lint-arch lint-quality build test run run-job setup-env teardown-env
+
+help:  ## 列出可用目标
+	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
+
+install-deps:  ## 安装 Python 依赖（系统级 TA-Lib native 库需另行安装，见 docs/DEVELOPMENT.md）
+	$(PY) -m pip install -r requirements.txt
+
+lint: lint-arch lint-quality  ## 跑全部 linter
+
+lint-arch:  ## 检查包层级依赖（lib 不得 import core 等）
+	$(PY) $(LINT_DEPS) instock
+
+lint-quality:  ## 检查基础代码质量
+	$(PY) $(LINT_QUALITY) instock
+
+build:  ## 编译检查（无未提交的语法错误）
+	$(PY) -m compileall -q instock
+
+test:  ## 运行测试（项目暂无测试套件，占位——加测试后在此接入）
+	@echo "尚无测试套件；新增 tests/ 后在此目标接入 pytest"
+
+run:  ## 启动 Web 服务（端口 9988）
+	bash harness/scripts/start-server.sh
+
+run-job:  ## 跑全量 job，可传日期参数：make run-job ARGS="2023-03-01"
+	bash harness/scripts/run-job.sh $(ARGS)
+
+setup-env:  ## 启动依赖服务（MariaDB）
+	bash harness/scripts/setup-env.sh
+
+teardown-env:  ## 关闭依赖服务
+	bash harness/scripts/teardown-env.sh

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,163 @@
+# InStock 使用说明
+
+InStock 是 A 股量化系统：抓取每日行情/基本面数据，计算技术指标与 K 线形态，综合选股、回测，提供 Web 展示与实盘交易。本文只讲**配置、构建、运行**。详细架构与开发见 `docs/`。
+
+---
+
+## 一、环境要求
+
+| 依赖 | 说明 |
+|---|---|
+| Python | 3.11（Docker 镜像内置） |
+| MariaDB / MySQL | 数据存储，默认 `localhost:3306` |
+| TA-Lib native 库 | 技术指标计算依赖，需先编译安装 C 库再装 Python 包 |
+| Redis 等其他服务 | 无 |
+
+Python 依赖见 `requirements.txt`（含 numpy/pandas/TA_Lib/tornado/PyMySQL/SQLAlchemy/easytrader 等）。
+
+---
+
+## 二、配置
+
+### 1. 数据库
+
+配置读环境变量，未设则用默认值（见 `instock/lib/database.py:14-36`）：
+
+| 环境变量 | 默认值 |
+|---|---|
+| `db_host` | `localhost` |
+| `db_port` | `3306` |
+| `db_user` | `root` |
+| `db_password` | `root` |
+| `db_database` | `instockdb` |
+
+本地示例：
+
+```sh
+export db_host=127.0.0.1 db_user=root db_password=你的密码 db_database=instockdb
+```
+
+Docker 部署时 `docker-compose.yml` 已设 `db_host=InStockDbService`，密码默认 `root`。
+
+### 2. 东方财富 Cookie（数据抓取需要）
+
+优先级：环境变量 `EAST_MONEY_COOKIE` > `instock/config/eastmoney_cookie.txt` > 默认值（见 `instock/core/eastmoney_fetcher.py:34`）。
+
+```sh
+export EAST_MONEY_COOKIE='从浏览器复制的 cookie 串'
+```
+
+### 3. 配置文件（`instock/config/`）
+
+| 文件 | 用途 |
+|---|---|
+| `eastmoney_cookie.txt` | cookie 备用存放（未用环境变量时） |
+| `proxy.txt` | 抓取代理（可选，Docker 通过 volume 挂载 `/data/instockproxy.txt`） |
+| `trade_client.json` | 自动交易客户端配置（仅用交易功能时需要） |
+
+---
+
+## 三、构建
+
+### 方式 A：Docker（推荐，开箱即用）
+
+```sh
+# 拉取官方镜像
+docker pull mayanghua/instock:latest
+
+# 启动（含 MariaDB）
+cd docker
+docker-compose up -d
+```
+
+`docker-compose.yml` 会拉起两个容器：`InStockDbService`（MariaDB）和 `InStock`（Web+Job+Cron，端口 9988）。
+
+### 方式 B：本地构建 Docker 镜像
+
+```sh
+cd docker
+./build.sh        # 同步代码、构建并推送 mayanghua/instock:latest
+# 仅构建不推送：docker build -f Dockerfile -t myinstock .
+```
+
+### 方式 C：本地源码运行
+
+```sh
+# 1. 安装 TA-Lib C 库（macOS: brew install ta-lib；Linux: 从源码 ./configure && make && make install）
+# 2. 安装 Python 依赖
+pip install -r requirements.txt
+```
+
+---
+
+## 四、运行
+
+### 1. 初始化数据库（首次必须）
+
+```sh
+python instock/job/init_job.py        # 创建库表
+```
+
+### 2. 启动 Web 服务
+
+```sh
+python instock/web/web_service.py     # 访问 http://localhost:9988/
+```
+
+### 3. 跑数据作业
+
+```sh
+# 全量当日作业
+python instock/job/execute_daily_job.py
+
+# 单日：python instock/job/execute_daily_job.py 2023-03-01
+# 批量：python instock/job/execute_daily_job.py 2023-03-01,2023-03-02
+# 区间：python instock/job/execute_daily_job.py 2023-03-01 2023-03-21
+
+# 单个作业（如综合选股）
+python instock/job/selection_data_daily_job.py
+```
+
+作业清单：`init_job`（建库）、`basic_data_daily_job`（基础数据实时）、`basic_data_other_daily_job`（非实时）、`indicators_data_daily_job`（指标）、`klinepattern_data_daily_job`（K 线形态）、`selection_data_daily_job`（选股）、`strategy_data_daily_job`（策略）、`backtest_data_daily_job`（回测）。
+
+### 4. 实盘交易（可选）
+
+```sh
+python instock/trade/trade_service.py
+```
+
+需先配置 `instock/config/trade_client.json`，券商客户端用法见 `instock/trade/usage.md`。
+
+### 5. 进程托管（Docker 内置，本地可选）
+
+```sh
+supervisord -c supervisor/supervisord.conf
+```
+
+托管三个进程：`run_job`（一次性作业）、`run_web`（Web，自动重启）、`run_cron`（cron 调度）。
+
+Docker 内 cron 调度（见 `docker/Dockerfile`）：
+
+```
+*/30 9,10,11,13,14,15 * * 1-5   # 盘中每 30 分钟跑基础数据
+30 17 * * 1-5                   # 收盘后跑全量作业
+30 10 * * 3,6                   # 周三、周六清缓存
+```
+
+---
+
+## 五、常用命令速查
+
+| 操作 | 命令 |
+|---|---|
+| Docker 启动 | `cd docker && docker-compose up -d` |
+| Docker 停止 | `cd docker && docker-compose down` |
+| 建库 | `python instock/job/init_job.py` |
+| 启 Web | `python instock/web/web_service.py` |
+| 跑全量作业 | `python instock/job/execute_daily_job.py` |
+| 跑区间作业 | `python instock/job/execute_daily_job.py 2023-03-01 2023-03-21` |
+| 进程托管 | `supervisord -c supervisor/supervisord.conf` |
+| Lint | `make lint-arch` |
+| Web 访问 | http://localhost:9988/ |
+
+> 入口脚本会自动把项目根加入 `sys.path`（见 `instock/web/web_service.py:16`、`instock/job/execute_daily_job.py:13`），本地源码运行无需手动设 `PYTHONPATH`；Docker 内 `PYTHONPATH=/data/InStock`（见 `docker/Dockerfile:10`）。

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,68 @@
+# ARCHITECTURE.md
+
+InStock 分层架构。每条论断标注 `file:line`。
+
+## 层级图
+
+```mermaid
+graph TD
+    subgraph entry[入口层]
+        JOB["job/*_daily_job.py<br/>execute_daily_job.py"]
+        WEB["web/web_service.py"]
+        TRADE["trade/trade_service.py"]
+    end
+    subgraph core[核心层 core]
+        CORE["core/*<br/>crawling/indicator/kline/pattern/strategy/backtest"]
+        LIB["lib/database.py<br/>lib/torndb.py<br/>lib/run_template.py<br/>lib/trade_time.py"]
+        TRADESUB["trade/robot/engine<br/>trade/robot/infrastructure"]
+    end
+    JOB -->|import| LIB
+    JOB -->|import| CORE
+    WEB -->|import| CORE
+    WEB -->|import| LIB
+    TRADE -->|import| TRADESUB
+    TRADESUB -->|import| LIB
+    CORE --> LIB
+    LIB -->|⚠循环| CORE
+```
+
+## 层级表
+
+| 包 | 职责 | fan-in / fan-out | 入口点 |
+|---|---|---|---|
+| `instock/job` | 日作业编排与批跑 | fan-out: →lib(72), →core(39) | `execute_daily_job.py:35` main、9 个 `*_daily_job.py` 的 main |
+| `instock/web` | Tornado Web 展示与关注 | fan-out: →core(9), →lib | `web_service.py:71` main，端口 9988 |
+| `instock/trade` | 实盘交易引擎 | fan-out: →lib(12) | `trade_service.py:19` main |
+| `instock/core` | 抓取/指标/形态/策略/回测 | fan-in: job+web；fan-out: →lib(18) | `stockfetch.py`、`eastmoney_fetcher.py` |
+| `instock/lib` | DB、torndb、批跑模板、交易时间 | fan-out: →core(6 ⚠循环)；fan-in: 高 | `database.py`、`run_template.py` |
+| `instock/trade/robot` | MainEngine/ClockEngine/EventEngine | fan-out: →lib | `main_engine.py:22` MainEngine |
+
+边界调用统计（import 边数）：job→lib(72), job→core(39), core→lib(18), trade→lib(12), web→core(9), lib→core(6 ⚠循环), core→trade(0 imports)。
+
+## 热点函数（按 fan_in 排序）
+
+| fan_in | 函数 | 位置 |
+|---|---|---|
+| 31 | `eastmoney_fetcher.make_request` | `instock/core/eastmoney_fetcher.py:86` |
+| 22 | `torndb.Connection.get` | `instock/lib/torndb.py:157` |
+| 19 | `database.checkTableIsExist` | `instock/lib/database.py:158` |
+| 18 | `database.executeSql` | `instock/lib/database.py:172` |
+| 18 | `database.insert_db_from_df` | `instock/lib/database.py:69` |
+| 18 | `tablestructure.get_field_types` | `instock/core/tablestructure.py:1064` |
+| 15 | `ClockEngine.now` | `instock/trade/robot/engine/clock_engine.py:154` |
+| 12 | `singleton_proxy.get_proxies` | `instock/core/singleton_proxy.py:30` |
+
+`make_request` 是所有东方财富抓取的统一出口，被 `instock/core/crawling/stock_hist_em.py` 等多模块调用（`instock/core/crawling/stock_hist_em.py:44` 等）。
+
+## 已知问题
+
+- **lib→core 循环**：`instock/lib/trade_time.py:5` `from instock.core.singleton_trade_date import stock_trade_date`，lib 层依赖 core 层；既有结构，harness 不修，linter 标记。`trade_time` 又被 `instock/trade/robot/engine/clock_engine.py:10` 与 `instock/lib/run_template.py:10` 引用。
+- **execute_daily_job 部分 job 被注释**：`instock/job/execute_daily_job.py:49-56` 中指标、K线形态、策略、回测作业被注释，默认仅跑基础数据 + 选股 + 收盘数据。
+- **DB 默认弱口令**：`instock/lib/database.py:14-18` 默认 root/root，依赖环境变量覆盖。
+
+## 入口点清单
+
+- Web：`instock/web/web_service.py:71` `main()`，监听 9988（`web_service.py:76-77`）。
+- 交易：`instock/trade/trade_service.py:19` `main()`，构造 `MainEngine(broker='gf_client', ...)`（`trade_service.py:20-25`）。
+- 全量作业：`instock/job/execute_daily_job.py:35` `main()`，调度链见 `execute_daily_job.py:40-59`。
+- 9 个 job mains：`init_job.py:52`、`basic_data_daily_job.py:71`、`basic_data_other_daily_job.py`、`basic_data_after_close_daily_job.py`、`indicators_data_daily_job.py:156`、`klinepattern_data_daily_job.py`、`strategy_data_daily_job.py`、`backtest_data_daily_job.py`、`selection_data_daily_job.py:46`，统一由 `execute_daily_job.py` 调度或经 `run_template.run_with_args` 批跑。

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,113 @@
+# DEVELOPMENT.md
+
+InStock 开发与运行命令。所有命令来源于仓库实际文件，标注 `file:line`。
+
+## 环境准备
+
+- Python 3.11（`docker/Dockerfile:3` `python:3.11-slim-bullseye`）。
+- `pip install -r requirements.txt`（`requirements.txt:1-18`，含 numpy/pandas/TA_Lib/tornado/PyMySQL/easytrader 等）。
+- TA-Lib 需先编译 native 库再装 Python 包，编译步骤见 `docker/Dockerfile:46-53`（`curl` 下载 ta-lib tar.gz → `./configure && make && make install` → `pip install TA-Lib`）。本地需自行安装 ta-lib native。
+- 容器内额外通过 `Dockerfile` 装了 supervisor、mysqlclient、cron 等（`docker/Dockerfile:27-45`）。
+
+## 数据库
+
+- 后端 MariaDB（`docker/docker-compose.yml:5` `library/mariadb:latest`，容器名 `InStockDbService`）。
+- 配置走环境变量，默认 localhost:3306/root/root/instockdb，见 `instock/lib/database.py:14-36`：
+  - `db_host`、`db_user`、`db_password`、`db_database`、`db_port` 覆盖默认（`database.py:22-36`）。
+  - docker-compose 传入 `db_host: InStockDbService`（`docker/docker-compose.yml:20`）。
+- 初始化 DB：`python instock/job/init_job.py`，先 `check_database` 再 `create_new_database`（`instock/job/init_job.py:52-60`、`init_job.py:20-30`）。
+
+## 运行命令
+
+### Web
+
+```
+python instock/web/web_service.py
+```
+
+端口 9988，见 `instock/web/web_service.py:76-77`。脚本版 `instock/bin/run_web.sh:3` 用 `/usr/local/bin/python3`。
+
+### 全量作业
+
+```
+python instock/job/execute_daily_job.py
+python instock/job/execute_daily_job.py 2023-03-01
+python instock/job/execute_daily_job.py 2023-03-01,2023-03-02
+python instock/job/execute_daily_job.py 2023-03-01 2023-03-21
+```
+
+参数语义见 `instock/bin/run_job.sh:9-12`；编排顺序见 `instock/job/execute_daily_job.py:40-59`（建库→基础数据→选股→其它基础数据/指标/K线/策略→回测→收盘数据，其中部分 job 当前被注释）。
+
+### 单个作业
+
+```
+python instock/job/init_job.py
+python instock/job/selection_data_daily_job.py
+python instock/job/basic_data_daily_job.py
+python instock/job/basic_data_other_daily_job.py
+python instock/job/indicators_data_daily_job.py
+python instock/job/klinepattern_data_daily_job.py
+python instock/job/strategy_data_daily_job.py
+python instock/job/backtest_data_daily_job.py
+```
+
+清单见 `instock/bin/run_job.sh:14-22`。每个 job 内部用 `run_template.run_with_args` 支持同款日期参数，见 `instock/lib/run_template.py:17-58`。
+
+### 交易
+
+```
+python instock/trade/trade_service.py
+```
+
+`main()` 构造 `MainEngine(broker='gf_client', need_data, log_handler)`，加载策略后 `start()`，见 `instock/trade/trade_service.py:19-25`。券商账号配置在 `instock/config/trade_client.json`（`trade_service.py:10`）。
+
+## PYTHONPATH
+
+- 容器内 `PYTHONPATH=/data/InStock`（`docker/Dockerfile:10`、`instock/bin/run_cron.sh:4`）。
+- 本地各入口脚本自行 `sys.path.append` 项目根，见 `instock/web/web_service.py:16-18`、`instock/job/execute_daily_job.py:13-15`、`instock/job/init_job.py:10-12`。
+
+## Docker
+
+```
+cd docker && docker-compose up -d
+```
+
+- 起 MariaDB（`InStockDbService`）+ InStock（`InStock`，映射 9988 端口），见 `docker/docker-compose.yml:4-26`。
+- InStock 镜像 `ENTRYPOINT supervisord -n -c /data/InStock/supervisor/supervisord.conf`（`docker/Dockerfile:77`）。
+
+## supervisord
+
+```
+supervisord -c supervisor/supervisord.conf
+```
+
+三个 program（`supervisor/supervisord.conf:25-42`）：
+
+- `run_job`：`/data/InStock/instock/bin/run_job.sh`，`autorestart=false`，priority 100。
+- `run_web`：`/data/InStock/instock/bin/run_web.sh`，`autorestart=true`，priority 500。
+- `run_cron`：`/data/InStock/instock/bin/run_cron.sh`，`autorestart=true`，priority 900。
+
+## cron 调度
+
+容器内 crontab（`docker/Dockerfile:69-74`）：
+
+- `*/30 9,10,11,13,14,15 * * 1-5 /bin/run-parts /etc/cron.hourly` — 工作日盘中每 30 分钟跑 `cron/cron.hourly/run_hourly`，即 `basic_data_daily_job.py`（`cron/cron.hourly/run_hourly:3`）。
+- `30 17 * * 1-5 /bin/run-parts /etc/cron.workdayly` — 工作日 17:30 跑 `cron/cron.workdayly/run_workdayly`，即 `execute_daily_job.py`（`cron/cron.workdayly/run_workdayly:3`）。
+- `30 10 * * 3,6 /bin/run-parts /etc/cron.monthly` — 周三、六 10:00 跑 `cron/cron.monthly/run_monthly`，清缓存（`cron/cron.monthly/run_monthly:4`）。
+
+cron 进程由 `instock/bin/run_cron.sh` 启动（`run_cron.sh:11` `/usr/sbin/cron -f`），并将环境变量写入 `/etc/environment` 供 cron 任务继承（`run_cron.sh:8`）。
+
+## 配置文件
+
+- `instock/config/eastmoney_cookie.txt` — 东方财富 Cookie 文件（`instock/core/eastmoney_fetcher.py:40-46`）。
+- `instock/config/proxy.txt` — HTTP 代理列表，每行一个，`singleton_proxy.proxys` 随机选取（`instock/core/singleton_proxy.py:21-34`）。
+- `instock/config/trade_client.json` — 券商账号配置，供 `easytrader` `prepare`（`instock/trade/trade_service.py:10`、`instock/trade/robot/engine/main_engine.py:34-36`；格式见 `instock/trade/usage.md`）。
+- 环境变量 `EAST_MONEY_COOKIE`：优先级高于 cookie 文件（`instock/core/eastmoney_fetcher.py:34-37`）。
+
+## lint
+
+```
+make lint-arch
+```
+
+架构 lint（harness 创建后可用）。

--- a/docs/design-docs/data-pipeline.md
+++ b/docs/design-docs/data-pipeline.md
@@ -1,0 +1,66 @@
+# data-pipeline.md
+
+InStock 数据管线：抓取 → 落库 → 指标/形态 → 选股/策略 → 回测。论断标注 `file:line`。
+
+## 总流程
+
+`execute_daily_job.main()` 编排顺序（`instock/job/execute_daily_job.py:40-59`）：
+
+1. `init_job.main()` 建库（`execute_daily_job.py:40`）。
+2. `basic_data_daily_job.main()` 实时行情（`execute_daily_job.py:42`）。
+3. `selection_data_daily_job.main()` 综合选股（`execute_daily_job.py:44`）。
+4. 线程池并发：`basic_data_other_daily_job.main()`（`execute_daily_job.py:47`），指标/K线/策略/回测当前被注释（`execute_daily_job.py:49-56`）。
+5. `basic_data_after_close_daily_job.main()` 收盘数据（`execute_daily_job.py:59`）。
+
+每个 job 内部由 `run_template.run_with_args` 处理日期参数：无参取最近交易日（`instock/lib/run_template.py:48-58`，调 `trade_time.get_trade_date_last`），单参批量，双参区间并用 `ThreadPoolExecutor` 提交（`run_template.py:17-46`）。函数名前缀决定调用分支：`save_nph*` 传 `before=False`（`run_template.py:51-52`），`save_after_close*` 走另一支（`run_template.py:53-54`）。
+
+## 1. 数据抓取
+
+抓取层在 `instock/core/crawling/`，全部走 `eastmoney_fetcher.make_request`（`instock/core/eastmoney_fetcher.py:86`），封装 Cookie、代理、重试（`eastmoney_fetcher.py:51-60` Retry 3 次退避）。
+
+代表：`instock/core/crawling/stock_hist_em.py`
+
+- `stock_zh_a_spot_em()` 沪深京 A 股实时行情，分页拉取（`stock_hist_em.py:21-61`），列名重命名 + `pd.to_numeric` 清洗（`stock_hist_em.py:64-188`）。
+- `code_id_map_em()` 股票代码→市场 id 映射，`@lru_cache` 缓存（`stock_hist_em.py:191-310`）。
+- `stock_zh_a_hist()` 日/周/月 K 线，按 `secid` 区分沪 1./深 0.（`stock_hist_em.py:313-385`）。
+- `stock_zh_a_hist_min_em()` 分时（`stock_hist_em.py:388-515`）。
+
+抓取代理来自 `singleton_proxy.proxys.get_proxies()`，随机选 `instock/config/proxy.txt` 中一行（`instock/core/singleton_proxy.py:30-34`）。
+
+## 2. 落库
+
+落库统一走 `instock/lib/database.py`，DataFrame 入库核心是 `insert_db_from_df` / `insert_other_db_from_df`（`database.py:69-113`）：
+
+- 用 SQLAlchemy `engine()`（`database.py:50-51`，URL 在 `database.py:38-39`）。
+- `data.to_sql(if_exists='append')`，按 `cols_type` 决定列类型：None 推断、`False` 全 NVARCHAR(255)、字典则按字典（`database.py:90-98`）。
+- 落库后 `inspect.get_pk_constraint` 检查主键，无则 `ALTER TABLE ADD PRIMARY KEY`，并按 `indexs` 字典建索引（`database.py:103-111`）。
+- 重跑先 `checkTableIsExist`（`database.py:158-168`）+ `executeSql` `DELETE FROM ... where date=...`（`database.py:172-178`）。
+
+表结构与列类型来自 `instock/core/tablestructure.py`：`TABLE_CN_STOCK_SPOT`、`TABLE_CN_STOCK_INDICATORS`、`TABLE_CN_STOCK_SELECTION` 等常量 + `get_field_types`（`tablestructure.py:1064`）。代表用法见 `basic_data_daily_job.py:31-40`：取 `TABLE_CN_STOCK_SPOT['name']`、`get_field_types(TABLE_CN_STOCK_SPOT['columns'])`，再 `insert_db_from_df(data, table_name, cols_type, False, "`date`,`code`")`。
+
+Web 层用 `torndb.Connection`（`instock/lib/torndb.py:47`）做查询，`Connection.query`（`torndb.py:136`）与 `Connection.get`（`torndb.py:157`），连接配置来自 `database.MYSQL_CONN_TORNDB`（`database.py:45-46`，在 `web_service.py:59` 注入 `self.db`）。
+
+## 3. 指标 / 形态
+
+指标作业 `instock/job/indicators_data_daily_job.py`：
+
+- `prepare(date)` 取 `stock_hist_data(date).get_data()`（`indicators_data_daily_job.py:25-26`），`run_check` 用 `ThreadPoolExecutor(max_workers=40)` 并发调 `calculate_indicator.get_indicator`（`indicators_data_daily_job.py:61-83`），结果合并后落 `TABLE_CN_STOCK_INDICATORS`（`indicators_data_daily_job.py:33-55`）。
+- 二次筛选：`guess_buy` 按 `kdjk>=80 and kdjd>=70 and kdjj>=100 and rsi_6>=80 and cci>=100 and cr>=300 and wr_6>=-20 and vr>=160` 选买入候选（`indicators_data_daily_job.py:96-98`），`guess_sell` 用对称阈值（`indicators_data_daily_job.py:131-133`），分别落 `TABLE_CN_STOCK_INDICATORS_BUY` / `_SELL`。
+
+K 线形态在 `instock/core/pattern/pattern_recognitions.py`，由 `klinepattern_data_daily_job.py` 调度；指标计算核心在 `instock/core/indicator/calculate_indicator.py`，依赖 `talib`（`requirements.txt:5`）。
+
+## 4. 选股 / 策略
+
+- 综合选股：`selection_data_daily_job.py` 调 `stockfetch.fetch_stock_selection()`（`selection_data_daily_job.py:27`）落 `TABLE_CN_STOCK_SELECTION`（`selection_data_daily_job.py:31-41`）。
+- 策略作业：`strategy_data_daily_job.py` 驱动 `instock/core/strategy/` 下各策略模块，每个策略暴露 `check(code_name, data, date, threshold=60)` 布尔函数，组合多个 `enter.check_*` 子条件。代表：
+  - `turtle_trade.check_enter`：海龟法则，最近 60 日最高收盘价突破（`instock/core/strategy/turtle_trade.py:14-37`）。
+  - `breakthrough_platform.check`：平台突破，60 日均线 + 放量上涨 + 偏离区间，内部调 `enter.check_volume`（`instock/core/strategy/breakthrough_platform.py:17-49`）。
+  - `enter.check_volume`：放量上涨公共条件，5 日均量≥2 倍、成交额≥2 亿（`instock/core/strategy/enter.py:16-57`）。
+
+## 5. 回测
+
+`backtest_data_daily_job.py` 驱动 `instock/core/backtest/rate_stats.py`，对入选股票做收益率统计并落 `TABLE_CN_STOCK_BACKTEST_DATA`（列定义在 `tablestructure.TABLE_CN_STOCK_BACKTEST_DATA`，被指标作业 concat 引用见 `indicators_data_daily_job.py:115-116`）。
+
+## 缓存
+
+历史 K 线缓存目录 `instock/cache/hist/`，由 `stockfetch.py:29-31` 创建；`cron.monthly/run_monthly` 清空该目录（`cron/cron.monthly/run_monthly:4` `rm -rf /data/InStock/instock/cache/hist/*`）。

--- a/docs/design-docs/strategy-system.md
+++ b/docs/design-docs/strategy-system.md
@@ -1,0 +1,59 @@
+# strategy-system.md
+
+InStock 选股策略系统。论断标注 `file:line`。
+
+## 模块组织
+
+策略位于 `instock/core/strategy/`，每个文件一个独立策略，统一暴露 `check(code_name, data, date=None, threshold=60) -> bool` 布尔接口。`__init__.py` 为空（`instock/core/strategy/__init__.py:1-6`），仅作包标识，无注册表。
+
+策略文件清单（`ls instock/core/strategy/`）：
+
+- `turtle_trade.py` — 海龟突破
+- `breakthrough_platform.py` — 平台突破
+- `enter.py` — 公共子条件（放量上涨、海龟突破）
+- `backtrace_ma250.py`、`climax_limitdown.py`、`high_tight_flag.py`、`keep_increasing.py`、`low_atr.py`、`low_backtrace_increase.py`、`parking_apron.py`
+
+## 调度
+
+由 `instock/job/strategy_data_daily_job.py` 驱动（`execute_daily_job.py:52` 调用，当前在主流程中被注释，`execute_daily_job.py:52`）。`strategy_data_daily_job.py` 走 `run_template.run_with_args`（与其它 job 同款，见 `indicators_data_daily_job.py:158`、`selection_data_daily_job.py:47` 的同构 main）。
+
+策略不是插件式注册：调用方按需 import 各策略模块的 `check`，传入 `code_name=(date, code)` 与历史行情 DataFrame + 日期 + threshold=60，返回 True 即入选。
+
+## 公共子条件 enter.py
+
+`instock/core/strategy/enter.py` 提供复用条件：
+
+- `check_volume(code_name, data, date=None, threshold=60)`（`enter.py:16`）放量上涨：
+  - `p_change < 2` 或收盘<开盘 → False（`enter.py:28-29`）。
+  - `vol_ma5 = tl.MA(volume, 5)`（`enter.py:31-32`）。
+  - 成交额 `last_close * last_vol >= 2 亿`（`enter.py:46-47`）。
+  - 量比 `last_vol / mean_vol >= 2`（`enter.py:53-55`）。
+- `check_enter(code_name, data, date=None, threshold=60)`（`turtle_trade.py:14`，海龟法则子条件，实为同模块 `turtle_trade` 文件内）：最近 threshold 日最后收盘价 ≥ 区间最高收盘价（`turtle_trade.py:25-35`）。
+
+注：`turtle_trade.py:14` 的 `check_enter` 与 `enter.py` 是不同文件；`breakthrough_platform.py:37` 调用的是 `enter.check_volume`（`from instock.core.strategy import enter`，`breakthrough_platform.py:7`）。
+
+## 代表策略
+
+### turtle_trade.py（海龟交易法则）
+
+`instock/core/strategy/turtle_trade.py:14-37`：取 `data.tail(n=threshold)`，逐行求 `max_price`，最后收盘 `last_close >= max_price` 即入选。常量 `BALANCE = 200000`（`turtle_trade.py:9`）。
+
+### breakthrough_platform.py（平台突破）
+
+`instock/core/strategy/breakthrough_platform.py:17-49`：
+
+1. `ma60 = tl.MA(close, 60)`（`breakthrough_platform.py:29-30`）。
+2. 找 `open < ma60 <= close` 的突破日，且该日满足 `enter.check_volume`（`breakthrough_platform.py:35-39`）。
+3. 突破日之前任意一天的 `(ma60 - close)/ma60` 必须落在 `(-0.05, 0.2)`（`breakthrough_platform.py:44-47`）。
+
+### enter.py（放量上涨 + 海龟突破子条件）
+
+见上文「公共子条件」。
+
+## 与回测的衔接
+
+入选股票写入 `TABLE_CN_STOCK_BACKTEST_DATA` 相关列（`indicators_data_daily_job.py:115-116` 用 `pd.concat([data, DataFrame(columns=TABLE_CN_STOCK_BACKTEST_DATA['columns'])])` 占位），由 `backtest_data_daily_job.py` 驱动 `instock/core/backtest/rate_stats.py` 做收益率统计。策略作业与回测作业在 `execute_daily_job.py:49-56` 当前均被注释，需手动启用。
+
+## 数据依赖
+
+策略入参 `data` 为单只股票的历史日 K DataFrame，由 `stock_hist_data(date).get_data()` 提供（`indicators_data_daily_job.py:26`），缓存于 `instock/cache/hist/`（`stockfetch.py:29-31`）。指标列（`kdjk/kdjd/kdjj/rsi_6/cci/cr/wr_6/vr`）由 `calculate_indicator.get_indicator` 用 `talib` 计算（`indicators_data_daily_job.py:69`）。

--- a/docs/design-docs/trade-engine.md
+++ b/docs/design-docs/trade-engine.md
@@ -1,0 +1,83 @@
+# trade-engine.md
+
+InStock 实盘交易引擎结构。论断标注 `file:line`。
+
+## 入口
+
+`instock/trade/trade_service.py:19` `main()`：
+
+```python
+broker = 'gf_client'
+log_handler = DefaultLogHandler(name='交易服务', log_type='file', filepath=log_filepath)
+m = MainEngine(broker, need_data, log_handler)
+m.is_watch_strategy = True
+m.load_strategy()
+m.start()
+```
+
+- `broker='gf_client'`（`trade_service.py:20`），券商账号文件 `need_data = config/trade_client.json`（`trade_service.py:10`）。
+- 日志路径 `log/stock_trade.log`（`trade_service.py:11`）。
+- `is_watch_strategy=True` 开启策略文件改动自动重载，注释明确「不建议在生产环境下使用」（`trade_service.py:23`）。
+
+支持的 broker 类型与 `easytrader.use` 用法见 `instock/trade/usage.md`（htzq_client / ht_client / gj_client / universal_client / ths / xq，`usage.md:9-49`）。
+
+## MainEngine 主引擎
+
+`instock/trade/robot/engine/main_engine.py:22` `class MainEngine`。
+
+职责：登录券商、启动事件/时钟引擎、动态加载策略、退出 shutdown。
+
+- 初始化（`main_engine.py:25-79`）：
+  - `easytrader.use(broker)` + `user.prepare(need_data)`；账号文件不存在则告警并降级（`main_engine.py:33-38`）。`broker is None` 时进入无交易模式（`main_engine.py:39-41`）。
+  - 构造 `EventEngine` 与 `ClockEngine`（`main_engine.py:43-44`）。
+  - 策略容器 `strategies: OrderedDict`、`strategy_list: list`（`main_engine.py:47-48`）。
+  - 退出信号 `SIGINT/SIGTERM`，非 Windows 加 `SIGHUP/SIGQUIT`，统一绑 `_shutdown`（`main_engine.py:68-77`）。
+- `start()`（`main_engine.py:81-90`）：启动 EventEngine → sleep 10s 等账户加载 → 启动 ClockEngine，并把二者 stop 注册到 `main_shutdown`。
+- `load_strategy(names=None)`（`main_engine.py:150-163`）：扫描 `strategies/` 目录下 `.py`（排除 `__init__.py`），逐个 `load`；`is_watch_strategy` 为真则启动 `_watch_thread` 轮询重载。
+- `load(names, strategy_file)`（`main_engine.py:92-133`）：按 `os.path.getmtime` 检测改动；有改动则 `importlib.reload`，从模块取 `Strategy` 类实例化，注册事件监听（`main_engine.py:135-148`）。
+- `_shutdown(sig, frame)`（`main_engine.py:201-231`）：依次 `before_shutdown` → `main_shutdown` → 各策略 `shutdown()` → `after_shutdown` → `sys.exit(1)`。
+
+## EventEngine 事件引擎
+
+`instock/trade/robot/engine/event_engine.py:19` `class EventEngine`。
+
+- `Queue` + 单消费线程 `__run`，每条事件起独立 `__process` 线程执行 handlers（`event_engine.py:36-52`）。
+- `register(event_type, handler)` / `unregister` 维护 `defaultdict(list)`（`event_engine.py:64-77`）。
+- `Event(event_type, data)`（`event_engine.py:13-16`）。
+
+## ClockEngine 时钟引擎
+
+`instock/trade/robot/engine/clock_engine.py:99` `class ClockEngine`。
+
+- `EventType = 'clock_tick'`（`clock_engine.py:104`），策略的 `clock(event)` 监听此类型（`main_engine.py:148`）。
+- `now` 属性返回 `time.time()`（`clock_engine.py:154-160`），`now_dt` 返回带时区 arrow 时间（`clock_engine.py:162-167`）。
+- 交易状态 `trading_state` 由 `trade_time.is_tradetime` + `is_trade_date` 判定（`clock_engine.py:119-120`）。
+- 默认注册的时刻事件（`clock_engine.py:126-148`）：`open`(09:00)、`pause`(11:30)、`continue`(13:00)、`close`(15:00，置 `trading_state=False`)；间隔事件 0.5/1/5/15/30/60 分钟（`clock_engine.py:151-152`）。
+- 两类 handler：`ClockMomentHandler`（时刻，`clock_engine.py:53-96`，支持仅交易日触发与补触发）、`ClockIntervalHandler`（间隔，`clock_engine.py:23-50`，可限定交易阶段）。
+- 非交易日 `tock` 直接跳过（`clock_engine.py:177-181`）。
+
+## StrategyTemplate 策略模板
+
+`instock/trade/robot/infrastructure/strategy_template.py:9` `class StrategyTemplate`。
+
+- 类属性 `name`（`strategy_template.py:10`）；`__init__(user, log_handler, main_engine)` 注入 `user`、`main_engine`、`clock_engine`，并调 `init()`（`strategy_template.py:12-18`）。
+- 子类可重写：`init` 注册时钟事件、`strategy` 执行逻辑、`clock(event)` 响应时钟、`log_handler` 自定义日志、`shutdown` 收尾（`strategy_template.py:20-42`）。
+
+## DefaultLogHandler
+
+`instock/trade/robot/infrastructure/default_handler.py:15`。基于 `logbook`，`log_type='stdout'` 输出屏幕、`'file'` 写文件（`default_handler.py:27-33`）；`__getattr__` 代理到内部 `Logger`（`default_handler.py:35-36`）。
+
+## 内置策略示例
+
+`instock/trade/strategies/stagging.py:14` `class Strategy(StrategyTemplate)`：
+
+- `name = 'stagging'`（`stagging.py:15`）。
+- `init` 注册 10:00 时刻事件与 1.5 分钟间隔事件（`stagging.py:24-30`）。
+- `strategy` 调 `self.user.auto_ipo()` 打新（`stagging.py:32-34`）。
+- `clock` 在 `event.data.clock_event == self.name` 时触发 `strategy`（`stagging.py:36-42`）。
+
+策略目录由 `MainEngine.load_strategy` 扫描 `strategies/`（`main_engine.py:153-156`），即 `instock/trade/strategies/`。
+
+## broker 客户端
+
+`easytrader`（`requirements.txt:15`）提供券商客户端封装，`MainEngine` 在 `__init__` 中 `easytrader.use(broker).prepare(need_data)`（`main_engine.py:33-36`）。`prepare` 配置文件格式见 `instock/trade/usage.md:92-123`（银河/国金、华泰、雪球三种）。

--- a/docs/design-docs/web-layer.md
+++ b/docs/design-docs/web-layer.md
@@ -1,0 +1,51 @@
+# web-layer.md
+
+InStock Web 层基于 Tornado。论断标注 `file:line`。
+
+## 入口与路由
+
+`instock/web/web_service.py:35` `class Application(tornado.web.Application)`，`__init__` 注册路由表（`web_service.py:37-48`）：
+
+| 路由 | Handler | 说明 |
+|---|---|---|
+| `/` | `HomeHandler` | 首页（`web_service.py:39`） |
+| `/instock/` | `HomeHandler` | 首页（`web_service.py:40`） |
+| `/instock/api_data` | `dataTableHandler.GetStockDataHandler` | 报表数据 JSON 接口（`web_service.py:42`） |
+| `/instock/data` | `dataTableHandler.GetStockHtmlHandler` | 报表页面（`web_service.py:43`） |
+| `/instock/data/indicators` | `dataIndicatorsHandler.GetDataIndicatorsHandler` | 股票指标/K 线（`web_service.py:45`） |
+| `/instock/control/attention` | `dataIndicatorsHandler.SaveCollectHandler` | 加入/取消关注（`web_service.py:47`） |
+
+配置（`web_service.py:49-56`）：模板 `templates/`、静态 `static/`、`xsrf_cookies=False`、`cookie_secret` 固定值、`debug=True`。
+
+全局 DB 连接在 `Application.__init__` 末尾注入：`self.db = torndb.Connection(**mdb.MYSQL_CONN_TORNDB)`（`web_service.py:59`），连接参数来自 `instock/lib/database.py:45-46`。
+
+## main()
+
+`web_service.py:71` `main()`：关闭 tornado 日志（`web_service.py:73`），建 `HTTPServer` 监听 9988（`web_service.py:75-77`），启动 `IOLoop`（`web_service.py:82`）。脚本版 `instock/bin/run_web.sh:3`。
+
+## BaseHandler
+
+`instock/web/base.py:13` `class BaseHandler(tornado.web.RequestHandler, ABC)`。
+
+- `db` property 每次访问先 `SELECT 1` 探活，失败则 `reconnect`（`base.py:14-22`）。
+- `LeftMenu`（`base.py:25-28`）从 `singleton_stock_web_module_data.stock_web_module_data().get_data_list()` 取左侧菜单。
+- `GetLeftMenu(url)` 工厂（`base.py:32-33`），被各 handler `render` 时传入。
+
+## dataTableHandler
+
+`instock/web/dataTableHandler.py`。
+
+- `MyEncoder(json.JSONEncoder)`（`dataTableHandler.py:18-28`）：bytes → 是/否；`datetime.date` → `/OADate(...)/` 串。
+- `GetStockHtmlHandler.get`（`dataTableHandler.py:33-43`）：按 `table_name` 取 `web_module_data`，根据 `is_realtime` 决定日期（实时用 `run_date_nph`，否则 `run_date`，调 `trade_time.get_trade_date_last`，`dataTableHandler.py:37-41`），渲染 `stock_web.html`。
+- `GetStockDataHandler.get`（`dataTableHandler.py:47-71`）：按 `name`/`date` 拼 `SELECT *{order_columns} FROM {table_name} WHERE date=%s ORDER BY ...`，`self.db.query(sql, date)` 取数，`json.dumps(data, cls=MyEncoder)` 返回（`dataTableHandler.py:54-71`）。`order_by`/`order_columns` 来自 `web_module_data`（`dataTableHandler.py:60-66`）。
+
+## dataIndicatorsHandler
+
+`instock/web/dataIndicatorsHandler.py`。
+
+- `GetDataIndicatorsHandler.get`（`dataIndicatorsHandler.py:16-40`）：按 `code` 前缀分流——`1`/`5` 开头调 `stockfetch.fetch_etf_hist`，否则 `fetch_stock_hist`（`dataIndicatorsHandler.py:24-27`）；再用 `kline.visualization.get_plot_kline` 生成图（`dataIndicatorsHandler.py:31-32`），渲染 `stock_indicators.html`。
+- `SaveCollectHandler.get`（`dataIndicatorsHandler.py:44-65`）：按 `otype` 在 `TABLE_CN_STOCK_ATTENTION['name']` 上 `DELETE`/`INSERT`（`dataIndicatorsHandler.py:53-60`），统一返回 `{"data":[{}]}`。
+
+## 依赖
+
+Web 层 fan-out：→core(9)（`stockfetch`、`singleton_stock_web_module_data`、`kline.visualization`、`tablestructure`）、→lib（`torndb`、`database`、`trade_time`）。`Application.db` 走 torndb（`web_service.py:59`），`BaseHandler.db` 走 `self.application.db`（`base.py:14-22`）。

--- a/harness/config/environment.json
+++ b/harness/config/environment.json
@@ -1,0 +1,176 @@
+{
+  "schema_version": "2.0",
+  "project": {
+    "name": "InStock",
+    "description": "Python 股票量化系统（A股数据采集、指标计算、策略选股、Web 展示）",
+    "root": ".",
+    "python_entry": "instock"
+  },
+  "services": {
+    "mariadb": {
+      "type": "mariadb",
+      "host": "localhost",
+      "port": 3306,
+      "user": "root",
+      "password": "${db_password}",
+      "database": "instockdb",
+      "charset": "utf8mb4",
+      "version": "latest",
+      "driver": "pymysql",
+      "orm": "sqlalchemy",
+      "connection_url": "mysql+pymysql://${db_user}:${db_password}@${db_host}:${db_port}/${db_database}?charset=utf8mb4",
+      "notes": "torndb 与 sqlalchemy 共用同一组连接参数，由 instock/lib/database.py 从环境变量加载"
+    }
+  },
+  "web_server": {
+    "framework": "tornado",
+    "port": 9988,
+    "entry": "instock/web/web_service.py",
+    "url": "http://localhost:9988/",
+    "routes": [
+      "/",
+      "/instock/",
+      "/instock/api_data",
+      "/instock/data",
+      "/instock/data/indicators",
+      "/instock/control/attention"
+    ]
+  },
+  "process_manager": {
+    "name": "supervisord",
+    "config_path": "supervisor/supervisord.conf",
+    "programs": [
+      "run_job",
+      "run_web",
+      "run_cron"
+    ],
+    "notes": "Docker 容器入口为 supervisord -n -c supervisor/supervisord.conf，本地运行可不依赖 supervisor"
+  },
+  "scheduler": {
+    "type": "cron",
+    "rules": [
+      {
+        "expression": "*/30 9,10,11,13,14,15 * * 1-5",
+        "target": "cron.hourly",
+        "entry": "instock/job/basic_data_daily_job.py",
+        "description": "工作日盘中（9-11/13-15 点）每 30 分钟执行基础数据实时作业"
+      },
+      {
+        "expression": "30 17 * * 1-5",
+        "target": "cron.workdayly",
+        "entry": "instock/job/execute_daily_job.py",
+        "description": "工作日 17:30 执行综合收盘作业"
+      },
+      {
+        "expression": "30 10 * * 3,6",
+        "target": "cron.monthly",
+        "entry": "清空 instock/cache/hist 缓存",
+        "description": "每周三、六 10:30 清理缓存数据"
+      }
+    ],
+    "source": "docker/Dockerfile (crontab)"
+  },
+  "env_vars": {
+    "db_host": {
+      "required": false,
+      "default": "localhost",
+      "secret": false,
+      "description": "数据库主机，Docker 容器内为 InStockDbService"
+    },
+    "db_user": {
+      "required": false,
+      "default": "root",
+      "secret": false,
+      "description": "数据库用户"
+    },
+    "db_password": {
+      "required": false,
+      "default": "root",
+      "secret": true,
+      "description": "数据库密码，Docker 镜像默认 root，本地用 ${db_password} 占位"
+    },
+    "db_database": {
+      "required": false,
+      "default": "instockdb",
+      "secret": false,
+      "description": "数据库名称"
+    },
+    "db_port": {
+      "required": false,
+      "default": 3306,
+      "secret": false,
+      "description": "数据库端口"
+    },
+    "EAST_MONEY_COOKIE": {
+      "required": false,
+      "default": "",
+      "secret": true,
+      "description": "东方财富网 Cookie，优先级：环境变量 > config/eastmoney_cookie.txt > 内置默认"
+    },
+    "PYTHONPATH": {
+      "required": false,
+      "default": ".",
+      "secret": false,
+      "description": "Python 模块搜索路径，Docker 内为 /data/InStock，本地为项目根"
+    }
+  },
+  "config_files": {
+    "dir": "instock/config",
+    "files": {
+      "eastmoney_cookie.txt": {
+        "purpose": "东方财富网 Cookie 文本，被 eastmoney_fetcher 回退读取",
+        "required": false
+      },
+      "proxy.txt": {
+        "purpose": "代理地址配置，被 singleton_proxy 读取",
+        "required": false
+      },
+      "trade_client.json": {
+        "purpose": "easytrader 交易客户端配置",
+        "required": false
+      }
+    }
+  },
+  "docker": {
+    "compose_path": "docker/docker-compose.yml",
+    "services": {
+      "instockdbservice": {
+        "image": "library/mariadb:latest",
+        "container_name": "InStockDbService",
+        "environment": {
+          "MYSQL_ROOT_PASSWORD": "root"
+        }
+      },
+      "instock": {
+        "image": "mayanghua/instock:latest",
+        "container_name": "InStock",
+        "ports": ["9988:9988"],
+        "environment": {
+          "db_host": "InStockDbService"
+        }
+      }
+    },
+    "startup": "cd docker && docker-compose up -d"
+  },
+  "dependencies": {
+    "python": {
+      "requirements": "requirements.txt",
+      "key_packages": [
+        "pymysql==1.1.2",
+        "SQLAlchemy==2.0.45",
+        "tornado==6.5.4",
+        "pandas==2.3.3",
+        "numpy==2.4.1",
+        "TA_Lib==0.6.8",
+        "easytrader==0.23.7"
+      ]
+    },
+    "system": {
+      "TA-Lib": {
+        "type": "native_library",
+        "install": "从 https://github.com/ta-lib/ta-lib/releases 下载 tar.gz，./configure && make && make install 后再 pip install TA-Lib",
+        "notes": "TA_Lib pip 包依赖系统级 ta-lib native 库，需先编译安装"
+      }
+    }
+  }
+}

--- a/harness/scripts/run-job.sh
+++ b/harness/scripts/run-job.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# run-job.sh — 包装运行 InStock 作业脚本
+# PONYTAIL：最小、自包含、可执行。密钥用环境变量传递。
+set -euo pipefail
+
+# 项目根目录
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# 设置 PYTHONPATH 为项目根（本地运行）
+export PYTHONPATH="${PROJECT_ROOT}"
+
+# 设置数据库环境变量（若未设置则使用默认值）
+export db_host="${db_host:-localhost}"
+export db_port="${db_port:-3306}"
+export db_user="${db_user:-root}"
+export db_database="${db_database:-instockdb}"
+
+if [ -z "${db_password:-}" ]; then
+  echo "[run-job] 警告：db_password 未设置，使用占位符 \${db_password}。请在调用前 export db_password=<真实密码>。"
+  export db_password="${db_password}"
+else
+  export db_password="${db_password}"
+fi
+
+# 东方财富 Cookie（可选）
+if [ -n "${EAST_MONEY_COOKIE:-}" ]; then
+  export EAST_MONEY_COOKIE
+fi
+
+echo "[run-job] PYTHONPATH=${PYTHONPATH}"
+echo "[run-job] 执行作业：python instock/job/execute_daily_job.py $*"
+echo "[run-job] 用法："
+echo "    无参数       — 整体作业（当天）"
+echo "    2023-03-01   — 单日作业"
+echo "    2023-03-01,2023-03-02 — 批量作业"
+echo "    2023-03-01 2023-03-21 — 区间作业"
+
+# 执行作业脚本，透传所有参数
+cd "${PROJECT_ROOT}"
+python instock/job/execute_daily_job.py "$@"

--- a/harness/scripts/setup-env.sh
+++ b/harness/scripts/setup-env.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# setup-env.sh — 启动 InStock 运行时依赖服务（MariaDB）
+# PONYTAIL：最小、自包含、可执行。密钥用 ${db_password} 占位，绝不硬编码真实密码。
+set -euo pipefail
+
+# 项目根目录（脚本位于 harness/scripts/，向上两级）
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COMPOSE_FILE="${PROJECT_ROOT}/docker/docker-compose.yml"
+
+# 从 environment.json 读取默认值（若 jq 可用），否则使用硬编码默认
+DB_HOST="${db_host:-localhost}"
+DB_PORT="${db_port:-3306}"
+DB_USER="${db_user:-root}"
+DB_DATABASE="${db_database:-instockdb}"
+
+# 数据库密码：优先继承已导出的环境变量；否则提示用户用 ${db_password} 占位
+if [ -n "${db_password:-}" ]; then
+  DB_PASSWORD="${db_password}"
+else
+  DB_PASSWORD="${db_password}"
+  echo "[setup-env] 提示：db_password 未设置，使用占位符 \${db_password}。请在调用前 export db_password=<真实密码>。"
+fi
+
+echo "[setup-env] 配置：host=${DB_HOST} port=${DB_PORT} user=${DB_USER} db=${DB_DATABASE}"
+
+# 优先用 docker-compose 启动 MariaDB 依赖服务
+if command -v docker >/dev/null 2>&1; then
+  if docker compose version >/dev/null 2>&1; then
+    echo "[setup-env] 检测到 docker，启动 MariaDB 服务（instockdbservice）..."
+    docker compose -f "${COMPOSE_FILE}" up -d instockdbservice
+    echo "[setup-env] MariaDB 已通过 docker compose 启动。"
+  else
+    echo "[setup-env] docker 已安装但 docker compose 不可用，尝试 docker-compose v1..."
+    if command -v docker-compose >/dev/null 2>&1; then
+      docker-compose -f "${COMPOSE_FILE}" up -d instockdbservice
+      echo "[setup-env] MariaDB 已通过 docker-compose 启动。"
+    else
+      echo "[setup-env] 未找到 docker compose 插件，请手动启动 MariaDB（localhost:3306）。"
+    fi
+  fi
+else
+  echo "[setup-env] 未检测到 docker。请手动启动 MariaDB："
+  echo "    brew services install mariadb  (macOS)"
+  echo "    sudo systemctl start mariadb   (Linux)"
+  echo "  并确保监听 ${DB_HOST}:${DB_PORT}、用户 ${DB_USER}、数据库 ${DB_DATABASE} 已创建。"
+fi
+
+# 导出 db_* 环境变量供后续脚本（start-server.sh / run-job.sh）继承
+export db_host="${DB_HOST}"
+export db_port="${DB_PORT}"
+export db_user="${DB_USER}"
+export db_password="${DB_PASSWORD}"
+export db_database="${DB_DATABASE}"
+
+echo "[setup-env] 已导出 db_host / db_port / db_user / db_password / db_database 环境变量。"
+echo "[setup-env] 完成。"

--- a/harness/scripts/start-server.sh
+++ b/harness/scripts/start-server.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# start-server.sh — 启动 InStock Tornado Web 服务（端口 9988）
+# PONYTAIL：最小、自包含、可执行。密钥用环境变量传递，绝不硬编码。
+set -euo pipefail
+
+# 项目根目录（脚本位于 harness/scripts/，向上两级）
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# 设置 PYTHONPATH 为项目根（本地运行）
+export PYTHONPATH="${PROJECT_ROOT}"
+# 若已有 PYTHONPATH 环境变量则优先使用（Docker 内为 /data/InStock）
+if [ -n "${PYTHONPATH_OVERRIDE:-}" ]; then
+  export PYTHONPATH="${PYTHONPATH_OVERRIDE}"
+fi
+
+# 设置数据库环境变量（若未设置则使用默认值）
+export db_host="${db_host:-localhost}"
+export db_port="${db_port:-3306}"
+export db_user="${db_user:-root}"
+export db_database="${db_database:-instockdb}"
+
+if [ -z "${db_password:-}" ]; then
+  echo "[start-server] 警告：db_password 未设置，使用占位符 \${db_password}。请在调用前 export db_password=<真实密码>。"
+  export db_password="${db_password}"
+else
+  export db_password="${db_password}"
+fi
+
+# 东方财富 Cookie（可选，未设置则回退到 config/eastmoney_cookie.txt 或内置默认）
+if [ -n "${EAST_MONEY_COOKIE:-}" ]; then
+  export EAST_MONEY_COOKIE
+else
+  echo "[start-server] 提示：EAST_MONEY_COOKIE 未设置，将回退到 instock/config/eastmoney_cookie.txt 或内置默认 Cookie。"
+fi
+
+echo "[start-server] PYTHONPATH=${PYTHONPATH}"
+echo "[start-server] db_host=${db_host} db_port=${db_port} db_user=${db_user} db_database=${db_database}"
+echo "[start-server] 启动 Tornado Web 服务，访问地址：http://localhost:9988/"
+
+# 启动 Web 服务
+cd "${PROJECT_ROOT}"
+python instock/web/web_service.py

--- a/harness/scripts/teardown-env.sh
+++ b/harness/scripts/teardown-env.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# teardown-env.sh — 清理 InStock 运行时依赖服务
+# PONYTAIL：最小、自包含、可执行。
+set -euo pipefail
+
+# 项目根目录
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COMPOSE_FILE="${PROJECT_ROOT}/docker/docker-compose.yml"
+
+echo "[teardown-env] 开始清理..."
+
+# 若依赖由 docker compose 启动，则关闭
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  echo "[teardown-env] 检测到 docker compose，关闭容器..."
+  docker compose -f "${COMPOSE_FILE}" down
+  echo "[teardown-env] docker compose 容器已关闭。"
+elif command -v docker >/dev/null 2>&1 && command -v docker-compose >/dev/null 2>&1; then
+  echo "[teardown-env] 检测到 docker-compose v1，关闭容器..."
+  docker-compose -f "${COMPOSE_FILE}" down
+  echo "[teardown-env] docker-compose 容器已关闭。"
+else
+  echo "[teardown-env] 未检测到 docker，若 MariaDB 为本地服务请手动停止："
+  echo "    brew services stop mariadb  (macOS)"
+  echo "    sudo systemctl stop mariadb   (Linux)"
+fi
+
+echo "[teardown-env] 清理完成。"

--- a/scripts/lint-deps.py
+++ b/scripts/lint-deps.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""InStock 依赖层级 linter。
+
+用 ast 静态解析 instock/ 下所有 .py 文件，检查 instock 内部 import 是否
+符合架构层级规则。发现违规输出 agent-actionable 报告，退出码 1；否则 0。
+
+用法: python scripts/lint-deps.py [path]   # 默认 path=instock/
+"""
+
+import ast
+import os
+import sys
+
+# 架构层级映射（权威，来自知识图谱）。
+# Layer 0 foundation / Layer 1 core / Layer 2 domain / Layer 3 entry。
+LAYER_PACKAGES = {
+    'lib': 0,
+    'core': 1,
+    'trade': 2,
+    'job': 3,
+    'web': 3,
+}
+
+# 每个 importer 顶层包允许 import 的 instock 内部包集合。
+# 同包内 import（intra-package）始终允许；跨层只允许向下。
+# lib 不得 import 任何更高层 instock 包；core 可引 lib/core；trade 可引
+# lib/core/trade；job/web（entry）可引 lib/core/trade，entry 层之间不得互引。
+ALLOWED_IMPORTS = {
+    'lib': {'lib'},
+    'core': {'lib', 'core'},
+    'trade': {'lib', 'core', 'trade'},
+    'job': {'lib', 'core', 'trade', 'job'},
+    'web': {'lib', 'core', 'trade', 'web'},
+}
+
+# 各 importer 包违规时的规则说明。
+FORBIDDEN_REASON = {
+    'lib': '必须零内部依赖',
+    'core': '不得 import trade/job/web',
+    'trade': '不得 import job/web',
+    'job': '不得 import web（entry 层之间亦不得互引）',
+    'web': '不得 import job（entry 层之间亦不得互引）',
+}
+
+# 既有已知违规：键为 (文件相对路径, 被引模块)。
+# harness 阶段不修，仅标注。详见 docs/ARCHITECTURE.md。
+KNOWN_VIOLATIONS = {
+    ('instock/lib/trade_time.py', 'instock.core.singleton_trade_date'):
+        '已知既有违规，harness 阶段不修，见 docs/ARCHITECTURE.md。',
+}
+
+# 已知违规对应的修复建议（覆盖通用生成逻辑）。
+KNOWN_FIX_OPTIONS = {
+    ('instock/lib/trade_time.py', 'instock.core.singleton_trade_date'):
+        '把 stock_trade_date 挪到 lib，或把 trade_time 挪到 core。',
+}
+
+# 扫描时跳过的目录名。
+EXCLUDE_DIRS = {'__pycache__', 'static', 'templates', '.git', '.idea', 'venv', 'env'}
+
+
+def iter_py_files(root):
+    """遍历 root 下所有 .py 文件，跳过 EXCLUDE_DIRS 与 .gitignore 命中的文件。
+
+    返回的 rel 路径保留 instock/ 前缀（相对 root 的父目录），以便
+    package_of_file 与 KNOWN_VIOLATIONS 的键统一匹配。
+    """
+    base = os.path.dirname(root.rstrip('/')) or '.'
+    ignore_patterns = []
+    for gi in (os.path.join(root, '.gitignore'),
+               os.path.join(base, '.gitignore')):
+        if os.path.isfile(gi):
+            with open(gi, encoding='utf-8') as f:
+                for line in f:
+                    line = line.strip()
+                    if line and not line.startswith('#'):
+                        ignore_patterns.append(line)
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in EXCLUDE_DIRS]
+        for name in filenames:
+            if not name.endswith('.py'):
+                continue
+            full = os.path.join(dirpath, name)
+            rel = os.path.relpath(full, base).replace(os.sep, '/')
+            if any(p in rel for p in ignore_patterns):
+                continue
+            yield full, rel
+
+
+def package_of_file(rel_path):
+    """由文件相对路径推断其所属 instock 顶层包。
+
+    例：instock/lib/trade_time.py → 'lib'；instock/core/indicator/foo.py → 'core'。
+    instock/__init__.py 与 instock/bin/* 等不在 LAYER_PACKAGES 中，返回 None。
+    """
+    parts = rel_path.replace(os.sep, '/').split('/')
+    if len(parts) < 2 or parts[0] != 'instock':
+        return None
+    if parts[1] not in LAYER_PACKAGES:
+        return None
+    return parts[1]
+
+
+def target_package_of(module):
+    """从 import 模块名取 instock 下第一个子包名。
+
+    'instock.core.singleton_trade_date' → 'core'；'instock' → None。
+    """
+    if not module or not module.startswith('instock'):
+        return None
+    tail = module[len('instock'):].lstrip('.')
+    if not tail:
+        return None
+    return tail.split('.')[0]
+
+
+def extract_instock_imports(tree):
+    """从 ast 树提取所有 instock 内部 import，返回 [(lineno, module, symbol)]。
+
+    symbol 仅用于修复建议文本：ImportFrom 取首个 imported name；Import 取模块末段。
+    """
+    out = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith('instock'):
+                    symbol = alias.name.split('.')[-1]
+                    out.append((node.lineno, alias.name, symbol))
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ''
+            if mod.startswith('instock') and (node.level is None or node.level == 0):
+                symbol = node.names[0].name if node.names else mod.split('.')[-1]
+                out.append((node.lineno, mod, symbol))
+    return out
+
+
+def build_fix_options(importer_pkg, importer_module, symbol, target_pkg):
+    """为未知违规生成修复建议。"""
+    if importer_pkg == 'lib':
+        return '把 {} 挪到 lib，或把 {} 挪到 {}。'.format(symbol, importer_module, target_pkg)
+    return ('把 {} 挪到 {} 或更低层，'
+            '或把 {} 挪到 {}。').format(symbol, importer_pkg, importer_module, target_pkg)
+
+
+def lint(root):
+    violations = []
+    file_count = 0
+    for full, rel in iter_py_files(root):
+        file_count += 1
+        importer_pkg = package_of_file(rel)
+        if importer_pkg is None:
+            continue
+        try:
+            with open(full, encoding='utf-8') as f:
+                src = f.read()
+        except OSError as e:
+            violations.append(('?', rel, 0, '?', '无法读取文件: {}'.format(e)))
+            continue
+        try:
+            tree = ast.parse(src, filename=full)
+        except SyntaxError as e:
+            violations.append(('E', rel, e.lineno or 0, '?',
+                               '语法错误: {}'.format(e)))
+            continue
+
+        importer_layer = LAYER_PACKAGES[importer_pkg]
+        allowed = ALLOWED_IMPORTS[importer_pkg]
+        importer_module = os.path.splitext(os.path.basename(rel))[0]
+
+        for lineno, module, symbol in extract_instock_imports(tree):
+            target_pkg = target_package_of(module)
+            if target_pkg is None:
+                continue
+            if target_pkg in allowed:
+                continue
+            key = (rel.replace(os.sep, '/'), module)
+            known_extra = KNOWN_VIOLATIONS.get(key)
+            fix = (KNOWN_FIX_OPTIONS.get(key)
+                   if key in KNOWN_FIX_OPTIONS
+                   else build_fix_options(importer_pkg, importer_module,
+                                         symbol, target_pkg))
+            target_layer = LAYER_PACKAGES.get(target_pkg, '?')
+            violations.append((importer_pkg, rel, lineno, module,
+                               target_pkg, target_layer, fix, known_extra))
+
+    return violations, file_count
+
+
+def main(argv):
+    root = argv[1] if len(argv) > 1 else 'instock'
+    if not os.path.isdir(root):
+        print('错误: 路径不存在: {}'.format(root), file=sys.stderr)
+        return 2
+
+    violations, file_count = lint(root)
+
+    if not violations:
+        print('✓ 依赖层级检查通过（{} 个文件检查）'.format(file_count))
+        return 0
+
+    # ponytail: 已知违规降级为 warning（不致命），只在出现未知违规时 exit 1。
+    # 这样 CI 不会从第一天起就红，但能捕获新增层级回归。
+    errors = [v for v in violations if len(v) != 8 or v[7] is None]
+    warnings = [v for v in violations if len(v) == 8 and v[7] is not None]
+
+    for v in violations:
+        if len(v) == 5:  # 读取/语法错误
+            _, rel, lineno, _, msg = v
+            print('✗ {}:{}  {}'.format(rel, lineno, msg))
+            print('  Fix: 修复语法/编码后重跑。')
+            continue
+        importer_pkg, rel, lineno, module, target_pkg, target_layer, fix, known_extra = v
+        importer_layer = LAYER_PACKAGES[importer_pkg]
+        marker = '⚠' if known_extra else '✗'
+        print('{} {}:{}'.format(marker, rel, lineno))
+        print('  imports {} (layer {} → layer {})'.format(
+            module, importer_layer, target_layer))
+        print('  {} (layer {}) {}。'.format(
+            importer_pkg, importer_layer, FORBIDDEN_REASON[importer_pkg]))
+        if known_extra:
+            print('  {}'.format(known_extra))
+        print('  Fix options: {}'.format(fix))
+
+    if errors:
+        print('', file=sys.stderr)
+        print('✗ 依赖层级检查未通过：{} 处未知违规、{} 处已知违规（{} 个文件检查）'.format(
+            len(errors), len(warnings), file_count), file=sys.stderr)
+        return 1
+    print('⚠ 依赖层级检查通过（含 {} 处已知违规，见 docs/ARCHITECTURE.md；{} 个文件检查）'.format(
+        len(warnings), file_count))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/scripts/lint-quality.py
+++ b/scripts/lint-quality.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""InStock 基础质量 linter（纯 stdlib）。
+
+检查：bare except、tab/空格混用缩进、print 用于日志、job/web 缺 __main__ 入口。
+agent-actionable 输出 file:line + WHAT + HOW to fix。错误退出码 1，警告 0，
+--strict 时警告亦退出 1。
+
+用法: python scripts/lint-quality.py [path] [--strict]   # 默认 path=instock/
+"""
+
+import ast
+import os
+import sys
+
+# entry 层包：模块应有 if __name__ == "__main__": 入口。
+ENTRY_PACKAGES = {'job', 'web'}
+
+# 扫描时跳过的目录名。
+EXCLUDE_DIRS = {'__pycache__', 'static', 'templates', '.git', '.idea', 'venv', 'env'}
+
+
+def iter_py_files(root):
+    base = os.path.dirname(root.rstrip('/')) or '.'
+    ignore_patterns = []
+    for gi in (os.path.join(root, '.gitignore'),
+               os.path.join(base, '.gitignore')):
+        if os.path.isfile(gi):
+            with open(gi, encoding='utf-8') as f:
+                for line in f:
+                    line = line.strip()
+                    if line and not line.startswith('#'):
+                        ignore_patterns.append(line)
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in EXCLUDE_DIRS]
+        for name in filenames:
+            if not name.endswith('.py'):
+                continue
+            full = os.path.join(dirpath, name)
+            rel = os.path.relpath(full, root).replace(os.sep, '/')
+            if any(p in rel for p in ignore_patterns):
+                continue
+            yield full, rel
+
+
+def package_of_file(rel_path):
+    parts = rel_path.replace(os.sep, '/').split('/')
+    if len(parts) < 2 or parts[0] != 'instock':
+        return None
+    if parts[1] in ENTRY_PACKAGES:
+        return parts[1]
+    return None
+
+
+def has_main_guard(tree):
+    """判断模块是否包含 if __name__ == "__main__": 入口。"""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        test = node.test
+        # __name__ == "__main__"
+        if isinstance(test, ast.Compare) and len(test.ops) == 1 and \
+                isinstance(test.ops[0], ast.Eq):
+            left = test.left
+            right = test.comparators[0] if test.comparators else None
+            if isinstance(left, ast.Name) and left.id == '__name__' and \
+                    isinstance(right, ast.Constant) and right.value == '__main__':
+                return True
+    return False
+
+
+def find_bare_excepts(tree):
+    """返回所有 bare except 的行号（ExceptHandler.type is None）。"""
+    out = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ExceptHandler) and node.type is None:
+            out.append(node.lineno)
+    return out
+
+
+def find_prints(tree):
+    """返回所有 print(...) 调用的行号。"""
+    out = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and \
+                node.func.id == 'print':
+            out.append(node.lineno)
+    return out
+
+
+def find_mixed_indent_lines(src):
+    """返回行内同时含 tab 与空格的缩进行号（1-based）。"""
+    bad = []
+    for i, line in enumerate(src.splitlines(), 1):
+        if not line:
+            continue
+        leading = line[:len(line) - len(line.lstrip(' \t'))]
+        if '\t' in leading and ' ' in leading:
+            bad.append(i)
+    return bad
+
+
+def lint(root):
+    errors = []   # (severity 'E'/'W', rel, lineno, what, why, fix)
+    file_count = 0
+    for full, rel in iter_py_files(root):
+        file_count += 1
+        try:
+            with open(full, encoding='utf-8') as f:
+                src = f.read()
+        except OSError as e:
+            errors.append(('E', rel, 0, '无法读取文件',
+                           str(e), '修复文件权限/编码。'))
+            continue
+
+        try:
+            tree = ast.parse(src, filename=full)
+        except SyntaxError as e:
+            errors.append(('E', rel, e.lineno or 0, '语法错误',
+                           str(e), '修复语法后重跑。'))
+            continue
+
+        # bare except（error）
+        for lineno in find_bare_excepts(tree):
+            errors.append(('E', rel, lineno, 'bare except',
+                           'except: 会吞掉 KeyboardInterrupt/SystemExit 等所有异常。',
+                           '改为 except Exception: 或更具体的异常类型。'))
+
+        # tab/空格混用缩进（error）
+        for lineno in find_mixed_indent_lines(src):
+            errors.append(('E', rel, lineno, 'tab/空格混用缩进',
+                           '同一行的缩进同时使用了 tab 与空格，Python 解释器可能报 TabError。',
+                           '统一使用 4 个空格缩进。'))
+
+        # print 用于日志（warning）
+        for lineno in find_prints(tree):
+            errors.append(('W', rel, lineno, 'print() 用于日志',
+                           'print 输出无法被运维捕获/分级，且不带时间戳。',
+                           '用 logging.info/debug/warning 替代。'))
+
+        # job/web 模块缺 __main__ 入口（soft warning）
+        pkg = package_of_file(rel)
+        if pkg is not None and os.path.basename(rel) != '__init__.py':
+            if not has_main_guard(tree):
+                errors.append(('W', rel, 0,
+                               'entry 模块缺少 __main__ 入口',
+                               '{} 层模块作为入口应可直接 python 执行'.format(pkg),
+                               '补充 if __name__ == "__main__": 调用主逻辑。'))
+
+    return errors, file_count
+
+
+def main(argv):
+    args = [a for a in argv[1:] if not a.startswith('-')]
+    strict = '--strict' in argv[1:]
+    root = args[0] if args else 'instock'
+    if not os.path.isdir(root):
+        print('错误: 路径不存在: {}'.format(root), file=sys.stderr)
+        return 2
+
+    errors, file_count = lint(root)
+    if not errors:
+        print('✓ 质量检查通过（{} 个文件检查）'.format(file_count))
+        return 0
+
+    for sev, rel, lineno, what, why, fix in errors:
+        mark = '✗' if sev == 'E' else '⚠'
+        loc = '{}:{}'.format(rel, lineno) if lineno else rel
+        print('{} [{}] {}  {}'.format(mark, sev, loc, what))
+        print('  {}'.format(why))
+        print('  Fix: {}'.format(fix))
+
+    e = sum(1 for v in errors if v[0] == 'E')
+    w = sum(1 for v in errors if v[0] == 'W')
+    print('', file=sys.stderr)
+    print('✓ 质量检查: {} error, {} warning（{} 个文件检查）'.format(e, w, file_count),
+          file=sys.stderr)
+    if e > 0:
+        return 1
+    return 1 if strict and w > 0 else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## 本次 PR：为项目引入 AI Agent Harness 基础设施

让仓库本身成为 AI agent 的单一事实来源——agent 看不到的就不存在。本 PR 不改任何业务代码，只补文档、linter、运行时契约与构建入口。

**导航与文档**
- `AGENTS.md` — agent 入口导航地图（编号分节，每条论断 cite `file:line`）
- `docs/ARCHITECTURE.md` — 分层（entry: job/web → core: core/lib/trade）、边界调用统计、热点函数、入口点清单
- `docs/DEVELOPMENT.md` — 真实 run/build/lint 命令、cron 调度、配置文件
- `docs/design-docs/` — `data-pipeline` / `trade-engine` / `web-layer` / `strategy-system` 四份设计文档
- `USAGE.md` — 面向用户的精简使用说明（配置 / 构建 / 运行），原 README 不动

**机械执行的不变量（Linter，纯 stdlib）**
- `scripts/lint-deps.py` — 包层级依赖检查：lib(layer 0) 不得 import 更高层，core/trade/job/web 逐层向下约束
- `scripts/lint-quality.py` — bare except、tab/空格混用缩进、print 当日志等基础质量规则

**运行时契约**
  - `harness/config/environment.json` — DB / Web / supervisord / cron / env vars / config files 生态契约，密钥用 `${VAR}` 占位
  - `harness/scripts/{setup-env,start-server,teardown-env,run-job}.sh` — 自包含、已 chmod +x

  **构建入口**
  - `Makefile` — `help / install-deps / lint / lint-arch / lint-quality / build / test / run / run-job / setup-env / teardown-env`

### 关键发现（已在文档记录，本 PR 不修）

- **既有 `lib→core` 循环依赖**：`instock/lib/trade_time.py:5` → `instock.core.singleton_trade_date`。lib 本应为最底层。linter 检出并降级为 warning（exit 0），新增同类回归仍会 fail。
- `execute_daily_job.py` 中部分子作业默认被注释，仅跑建库 + 基础数据 + 选股。
- `lint-quality` 报 3 处 pre-existing bare-except（如 `trade/robot/infrastructure/strategy_wrapper.py:37`），属遗留代码问题，未在本次范围内处理。

### 使用

```sh
make help            # 看全部目标
make setup-env       # 起 MariaDB
make run             # 起 Web（9988）
make run-job ARGS="2023-03-01"
make lint-arch       # 层级依赖检查
